### PR TITLE
Add control-buffer-512 and -1024 feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ rand = "0.6.1"
 [features]
 # Use a 256 byte buffer for control transfers instead of 128.
 control-buffer-256 = []
+control-buffer-512 = []
+control-buffer-1024 = []
 
 # Use larger endpoint buffers for highspeed operation (default fullspeed)
 #

--- a/src/control_pipe.rs
+++ b/src/control_pipe.rs
@@ -21,10 +21,23 @@ enum ControlState {
 
 // Maximum length of control transfer data stage in bytes. 128 bytes by default. You can define the
 // feature "control-buffer-256" to make it 256 bytes if you have larger control transfers.
-#[cfg(not(feature = "control-buffer-256"))]
-const CONTROL_BUF_LEN: usize = 128;
-#[cfg(feature = "control-buffer-256")]
+
+#[cfg(feature = "control-buffer-1024")]
+const CONTROL_BUF_LEN: usize = 1024;
+#[cfg(all(not(feature = "control-buffer-1024"), feature = "control-buffer-512"))]
+const CONTROL_BUF_LEN: usize = 512;
+#[cfg(all(
+    not(feature = "control-buffer-1024"),
+    not(feature = "control-buffer-512"),
+    feature = "control-buffer-256"
+))]
 const CONTROL_BUF_LEN: usize = 256;
+#[cfg(all(
+    not(feature = "control-buffer-1024"),
+    not(feature = "control-buffer-512"),
+    not(feature = "control-buffer-256")
+))]
+const CONTROL_BUF_LEN: usize = 128;
 
 /// Buffers and parses USB control transfers.
 pub struct ControlPipe<'a, B: UsbBus> {


### PR DESCRIPTION
Hi,

thank you for your great work, it's great to see Rust becoming more and more capable also in the embedded domain!

Unfortunately, the usb-device crate provides a rather limited control buffer which is used for descriptors. This limits the descriptor size to a maximum of 256 when using the `control-buffer-256` feature flag. For USB-MIDI, for example, this is only enough for 5 in + 5 out ports, while up to 1024 bytes can be needed for larger descriptors providing up to 16 ports.

(See https://github.com/btrepp/usbd-midi/pull/6 for a scenario where this is relevant).

I added two additional feature flags to provide buffer sizes of 512 and 1024 bytes, respectively. I admit this seems a bit hacky, maybe resorting to the [typenum](https://docs.rs/typenum/1.13.0/typenum/) crate or waiting for const generics is the better way in the long run.

However, for now, I think that these additional feature flags bring the chance to greatly improve the usefulness of usb-device.

Feel free to contact me in case of any questions or change requests. :)
