### PR TITLE
Adding basic remote wakeup hooks

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -120,6 +120,21 @@ pub trait UsbBus: Sync + Sized {
     /// interrupt handler. See the [`PollResult`] struct for more information.
     fn poll(&self) -> PollResult;
 
+    /// Initiates the remote wakeup sequence
+    /// Implementation can vary wildly as some hardware handles the timing, others do not.
+    ///
+    /// The default implementation just returns `Unsupported`.
+    ///
+    /// # Errors
+    ///
+    /// * [`Unsupported`](crate::UsbError::Unsupported) - This UsbBus implementation doesn't support
+    ///   remote wakeup.
+    /// * [`NotSuspended`](crate::UsbError::NotSuspended) - Remote wakeup can only be called if the
+    ///   bus has been suspended.
+    fn remote_wakeup(&self) -> Result<()> {
+        Err(UsbError::Unsupported)
+    }
+
     /// Simulates a disconnect from the USB bus, causing the host to reset and re-enumerate the
     /// device.
     ///

--- a/src/device.rs
+++ b/src/device.rs
@@ -5,7 +5,7 @@ use crate::control_pipe::ControlPipe;
 use crate::descriptor::{descriptor_type, lang_id, BosWriter, DescriptorWriter};
 pub use crate::device_builder::{UsbDeviceBuilder, UsbVidPid};
 use crate::endpoint::{EndpointAddress, EndpointType};
-use crate::{Result, UsbDirection};
+use crate::{Result, UsbDirection, UsbError};
 
 /// The global state of the USB device.
 ///
@@ -130,6 +130,17 @@ impl<B: UsbBus> UsbDevice<'_, B> {
     /// Sets whether the device is currently self powered.
     pub fn set_self_powered(&mut self, is_self_powered: bool) {
         self.self_powered = is_self_powered;
+    }
+
+    /// Initiates a remote wakeup sequence
+    /// Used to wake the host device from sleep when enabled.
+    pub fn remote_wakeup(&self) -> Result<()> {
+        // Make sure remote wakeup has been enabled
+        if !self.remote_wakeup_enabled() {
+            return Err(UsbError::InvalidState);
+        }
+
+        self.bus.remote_wakeup()
     }
 
     /// Simulates a disconnect from the USB bus, causing the host to reset and re-enumerate the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,9 @@ pub enum UsbError {
 
     /// Operation is not valid in the current state of the object.
     InvalidState,
+
+    /// Operation requires bus to be suspended
+    NotSuspended,
 }
 
 /// Direction of USB traffic. Note that in the USB standard the direction is always indicated from


### PR DESCRIPTION
- Fixes #65
- Adds a new error type to indicate that the bus is not suspended
  (Bus must be suspended to initiate Remote Wakeup)
- The poll functions can be used for implementations that require
  interrupt handling after initiating the remote wakeup