### PR TITLE
Make Send+Sync impls optional for compatibility with AVR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ control-buffer-256 = []
 # speed device, but the descriptors will be invalid.
 test-class-high-speed = []
 
-
 [[test]]
 name = "test_class_host"
 path = "tests/test_class_host/main.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,9 @@ rusb = "0.8.0"
 rand = "0.6.1"
 
 [features]
-default = ["sync"]
-
 # Enable support for using this library across multiple threads.
 #
-# Enabled by default, but made optional for compatibility with AVR targets
+# Made optional / opt-in for compatibility with AVR targets
 # which are single-core and do not have atomic operations.
 sync = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,14 @@ rusb = "0.8.0"
 rand = "0.6.1"
 
 [features]
+default = ["sync"]
+
+# Enable support for using this library across multiple threads.
+#
+# Enabled by default, but made optional for compatibility with AVR targets
+# which are single-core and do not have atomic operations.
+sync = []
+
 # Use a 256 byte buffer for control transfers instead of 128.
 control-buffer-256 = []
 
@@ -23,6 +31,7 @@ control-buffer-256 = []
 # TestClass only compliant with high speed mode. It may still manage to be enumerated as a full
 # speed device, but the descriptors will be invalid.
 test-class-high-speed = []
+
 
 [[test]]
 name = "test_class_host"

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -77,6 +77,9 @@ impl<T: Sync> ConditionalSync for T {}
 #[cfg(not(feature = "sync"))]
 pub trait ConditionalSync {}
 
+#[cfg(not(feature = "sync"))]
+impl<T> ConditionalSync for T {}
+
 /// A trait for device-specific USB peripherals. Implement this to add support for a new hardware
 /// platform.
 ///

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -6,6 +6,7 @@ use core::ptr;
 
 #[cfg(feature = "sync")]
 use core::sync::atomic::{AtomicPtr, Ordering};
+
 #[cfg(not(feature = "sync"))]
 use core::cell::Cell;
 
@@ -29,20 +30,24 @@ impl<B> BusPtr<B> {
     }
 
     fn set(&self, ptr: *mut B) {
-        #[cfg(feature = "sync")] {
+        #[cfg(feature = "sync")]
+        {
             self.inner.store(ptr, Ordering::SeqCst);
         }
-        #[cfg(not(feature = "sync"))] {
+        #[cfg(not(feature = "sync"))]
+        {
             self.inner.set(ptr);
         }
     }
 
     pub(crate) fn get(&self) -> *mut B {
-        #[cfg(feature = "sync")] {
+        #[cfg(feature = "sync")]
+        {
             self.inner.load(Ordering::SeqCst)
         }
 
-        #[cfg(not(feature = "sync"))] {
+        #[cfg(not(feature = "sync"))]
+        {
             self.inner.get()
         }
     }

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -1,4 +1,4 @@
-use crate::bus::{UsbBus, BusPtr};
+use crate::bus::{BusPtr, UsbBus};
 use crate::{Result, UsbDirection};
 use core::marker::PhantomData;
 use core::ptr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,6 +192,7 @@ pub mod class_prelude {
     pub use crate::UsbError;
 }
 
+#[cfg(feature = "sync")]
 fn _ensure_sync() {
     use crate::bus::{PollResult, UsbBus, UsbBusAllocator};
     use crate::class_prelude::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,6 +192,9 @@ pub mod class_prelude {
     pub use crate::UsbError;
 }
 
+#[cfg(all(feature = "sync", target_arch = "avr"))]
+compile_error!("`sync` feature is not supported on AVR targets.");
+
 #[cfg(feature = "sync")]
 fn _ensure_sync() {
     use crate::bus::{PollResult, UsbBus, UsbBusAllocator};


### PR DESCRIPTION
The AVR architecture doesn't have atomic operations, but the chips are generally single-core anyway so thread safety isn't necessary.

This crate can't be used on AVR in official Rust yet, since this crate uses `dyn` / trait objects (rust-lang/rust#79889). But there is a pending fix, and I'm testing it out with [my own patched version of Rust/LLVM](https://github.com/agausmann/rust/tree/avr-patch/).