### PR TITLE
Panic on control buffer overflow

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -453,13 +453,12 @@ impl<B: UsbBus> UsbDevice<'_, B> {
         fn accept_writer<B: UsbBus>(
             xfer: ControlIn<B>,
             f: impl FnOnce(&mut DescriptorWriter) -> Result<()>,
-        ) {
+        ) -> Result<()> {
             xfer.accept(|buf| {
                 let mut writer = DescriptorWriter::new(buf);
                 f(&mut writer)?;
                 Ok(writer.position())
             })
-            .ok();
         }
 
         match dtype {
@@ -513,17 +512,16 @@ impl<B: UsbBus> UsbDevice<'_, B> {
                     };
 
                     if let Some(s) = s {
-                        accept_writer(xfer, |w| w.string(s));
+                        accept_writer(xfer, |w| w.string(s))
                     } else {
-                        xfer.reject().ok();
+                        xfer.reject()
                     }
                 }
             }
 
-            _ => {
-                xfer.reject().ok();
-            }
+            _ => xfer.reject(),
         }
+        .unwrap();
     }
 
     fn reset(&mut self, classes: &mut ClassList<'_, B>) {


### PR DESCRIPTION
- When writing larger interface descriptors it's possible to overflow
  the buffer (even on LS/FS USB 2.0)
- Cleanup get_descriptor and accept_writer to forward the error
- Then unwrap() it inside get_descriptor
  * unwrap() will panic regardless of the logging mechanism and give a
    useful error message (e.g. defmt):
    ERROR panicked at 'called `Result::unwrap()` on an `Err` value: BufferOverflow'
  * We want to panic as continuing usually halts/suspends the USB
    device which will usually retry enumeration a few times until the
    host gives up
  * This is most common during initial enumeration, but it's also
    possible when requesting debug descriptors (e.g. lsusb)
- Ideally we should return some sort of error that recommends enabling
  the control-buffer-256 feature but this isn't straightforward with the
  current design