### PR TITLE
Fix Suspend state transition to go back to the previous state (#96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 * Fixed an issue where USB devices were not enumerating on Windows ([#32](https://github.com/rust-embedded-community/usb-device/issues/82))
 * Add optional support for defmt ([#76](https://github.com/rust-embedded-community/usb-device/pull/76))
+* Fixed Suspend state transition so it goes back to the previous state, not just Default ([#97](https://github.com/rust-embedded-community/usb-device/pull/97))
 
 ...
 


### PR DESCRIPTION
- Per (https://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-11100-32-bit%20Cortex-M4-Microcontroller-SAM4S_Datasheet.pdf; 40.6.3 page 1042), the state transition from Suspend should go back to the previous state
- Previously Suspend would always transition back to Default state
- Fixes #96 