### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,7 +199,7 @@ fn _ensure_sync() {
     use crate::class_prelude::*;
 
     struct DummyBus<'a> {
-        a: &'a str,
+        _a: &'a str,
     }
 
     impl UsbBus for DummyBus<'_> {
@@ -239,12 +239,14 @@ fn _ensure_sync() {
     }
 
     struct DummyClass<'a, B: UsbBus> {
-        ep: crate::endpoint::EndpointIn<'a, B>,
+        _ep: crate::endpoint::EndpointIn<'a, B>,
     }
 
     impl<B: UsbBus> DummyClass<'_, B> {
-        fn new(alloc: &UsbBusAllocator<B>) -> DummyClass<'_, B> {
-            DummyClass { ep: alloc.bulk(64) }
+        fn _new(alloc: &UsbBusAllocator<B>) -> DummyClass<'_, B> {
+            DummyClass {
+                _ep: alloc.bulk(64),
+            }
         }
     }
 


### PR DESCRIPTION
- field xxx is never read
- associated funct xxx is never used
- Used _ to ignore the used fields and function