### PR TITLE
Device tests: Send bulk packet ZLP based on max packet size

### DIFF
--- a/tests/test_class_host/device.rs
+++ b/tests/test_class_host/device.rs
@@ -12,6 +12,25 @@ pub struct DeviceHandles {
     pub en_us: Language,
 }
 
+impl DeviceHandles {
+    /// Returns the max packet size for the `TestClass` bulk endpoint(s).
+    pub fn bulk_max_packet_size(&self) -> u16 {
+        self.config_descriptor
+            .interfaces()
+            .flat_map(|intf| intf.descriptors())
+            .flat_map(|desc| {
+                desc.endpoint_descriptors()
+                    .find(|ep| {
+                        // Assumes that IN and OUT endpoint MPSes are the same.
+                        ep.transfer_type() == rusb::TransferType::Bulk
+                    })
+                    .map(|ep| ep.max_packet_size())
+            })
+            .next()
+            .expect("TestClass has at least one bulk endpoint")
+    }
+}
+
 impl ::std::ops::Deref for DeviceHandles {
     type Target = DeviceHandle<Context>;
 

--- a/tests/test_class_host/device.rs
+++ b/tests/test_class_host/device.rs
@@ -13,6 +13,11 @@ pub struct DeviceHandles {
 }
 
 impl DeviceHandles {
+    /// Indicates if this device is (true) or isn't (false) a
+    /// high-speed device.
+    pub fn is_high_speed(&self) -> bool {
+        self.handle.device().speed() == rusb::Speed::High
+    }
     /// Returns the max packet size for the `TestClass` bulk endpoint(s).
     pub fn bulk_max_packet_size(&self) -> u16 {
         self.config_descriptor

--- a/tests/test_class_host/tests.rs
+++ b/tests/test_class_host/tests.rs
@@ -164,8 +164,13 @@ fn interface_descriptor(dev, _out) {
 }
 
 fn bulk_loopback(dev, _out) {
+    let mut lens = vec![0, 1, 2, 32, 63, 64, 65, 127, 128, 129];
+    if dev.is_high_speed() {
+        lens.extend([255, 256, 257, 511, 512, 513, 1023, 1024, 1025]);
+    }
+
     let max_packet_size: usize = dev.bulk_max_packet_size().into();
-    for len in &[0, 1, 2, 32, 63, 64, 65, 127, 128, 129] {
+    for len in &lens {
         let data = random_data(*len);
 
         assert_eq!(

--- a/tests/test_class_host/tests.rs
+++ b/tests/test_class_host/tests.rs
@@ -164,6 +164,7 @@ fn interface_descriptor(dev, _out) {
 }
 
 fn bulk_loopback(dev, _out) {
+    let max_packet_size: usize = dev.bulk_max_packet_size().into();
     for len in &[0, 1, 2, 32, 63, 64, 65, 127, 128, 129] {
         let data = random_data(*len);
 
@@ -173,7 +174,7 @@ fn bulk_loopback(dev, _out) {
             data.len(),
             "bulk write len {}", len);
 
-        if *len > 0 && *len % 64 == 0 {
+        if *len > 0 && *len % max_packet_size == 0 {
             assert_eq!(
                 dev.write_bulk(0x01, &[], TIMEOUT)
                     .expect("bulk write zero-length packet"),


### PR DESCRIPTION
The `bulk_loopback` device test sends a zero-length packet (ZLP) from host to device when the bulk endpoint packet size is a multiple of the max packet size (MPS). Before this commit, the MPS was hard-coded to 64, the MPS of the full-speed bulk endpoint. This commit updates the test to use the MPS that matches the full- / high-speed test class's MPS.

I was having issues testing a high-speed device with the test suite before this change (compiling both firmware and test suite with `test-class-high-speed` feature). Specifically, the test would fail when trying to read back data from the 65 byte transfer. I think I traced the issue back to this condition, but let me know if you think there might be an issue in my device driver. There's more notes in the commit message.