### PR TITLE
Fix link to embassy-usb

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ Others
 ------
 
 Other implementations for USB in Rust
-* [embassy-usb](https://github.com/embassy-rs/embassy/tree/master/embassy-usb) an async variant.
+* The [Embassy](https://github.com/embassy-rs/embassy) project has an async USB stack, embassy-usb.

--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ Others
 ------
 
 Other implementations for USB in Rust
-* [embassy-usb](https://github.com/embassy-rs/embassy/blob/master/embassy-usb/src/driver.rs), an async variant.
+* [embassy-usb](https://github.com/embassy-rs/embassy/tree/master/embassy-usb) an async variant.


### PR DESCRIPTION
The old link returned 404 as the file driver.rs was removed. Point to the crate root directory instead.

Alternatively, the link could point to the docs at https://docs.embassy.dev/embassy-usb/git/default/index.html