### PR TITLE
Add the ability to select USB revision

### DIFF
--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -110,12 +110,12 @@ impl DescriptorWriter<'_> {
         self.write(
             descriptor_type::DEVICE,
             &[
-                0x10,
-                0x02,                     // bcdUSB 2.1
-                config.device_class,      // bDeviceClass
-                config.device_sub_class,  // bDeviceSubClass
-                config.device_protocol,   // bDeviceProtocol
-                config.max_packet_size_0, // bMaxPacketSize0
+                (config.usb_rev as u16) as u8,
+                (config.usb_rev as u16 >> 8) as u8, // bcdUSB
+                config.device_class,                // bDeviceClass
+                config.device_sub_class,            // bDeviceSubClass
+                config.device_protocol,             // bDeviceProtocol
+                config.max_packet_size_0,           // bMaxPacketSize0
                 config.vendor_id as u8,
                 (config.vendor_id >> 8) as u8, // idVendor
                 config.product_id as u8,

--- a/src/device.rs
+++ b/src/device.rs
@@ -30,6 +30,18 @@ pub enum UsbDeviceState {
 // Maximum number of endpoints in one direction. Specified by the USB specification.
 const MAX_ENDPOINTS: usize = 16;
 
+/// Usb spec revision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u16)]
+pub enum UsbRev {
+    /// USB 2.0 compliance
+    Usb200 = 0x200,
+    /// USB 2.1 compliance.
+    ///
+    /// Typically adds support for BOS requests.
+    Usb210 = 0x210,
+}
+
 /// A USB device consisting of one or more device classes.
 pub struct UsbDevice<'a, B: UsbBus> {
     bus: &'a B,
@@ -49,6 +61,7 @@ pub(crate) struct Config<'a> {
     pub max_packet_size_0: u8,
     pub vendor_id: u16,
     pub product_id: u16,
+    pub usb_rev: UsbRev,
     pub device_release: u16,
     pub manufacturer: Option<&'a str>,
     pub product: Option<&'a str>,
@@ -469,7 +482,7 @@ impl<B: UsbBus> UsbDevice<'_, B> {
         }
 
         match dtype {
-            descriptor_type::BOS => accept_writer(xfer, |w| {
+            descriptor_type::BOS if config.usb_rev > UsbRev::Usb200 => accept_writer(xfer, |w| {
                 let mut bw = BosWriter::new(w);
                 bw.bos()?;
 

--- a/src/device_builder.rs
+++ b/src/device_builder.rs
@@ -1,5 +1,5 @@
 use crate::bus::{UsbBus, UsbBusAllocator};
-use crate::device::{Config, UsbDevice};
+use crate::device::{Config, UsbDevice, UsbRev};
 
 /// A USB vendor ID and product ID pair.
 pub struct UsbVidPid(pub u16, pub u16);
@@ -34,6 +34,7 @@ impl<'a, B: UsbBus> UsbDeviceBuilder<'a, B> {
                 max_packet_size_0: 8,
                 vendor_id: vid_pid.0,
                 product_id: vid_pid.1,
+                usb_rev: UsbRev::Usb210,
                 device_release: 0x0010,
                 manufacturer: None,
                 product: None,
@@ -87,6 +88,11 @@ impl<'a, B: UsbBus> UsbDeviceBuilder<'a, B> {
         ///
         /// Default: `false`
         supports_remote_wakeup: bool,
+
+        /// Sets which Usb 2 revision to comply to.
+        ///
+        /// Default: `UsbRev::Usb210`
+        usb_rev: UsbRev,
     }
 
     /// Configures the device as a composite device with interface association descriptors.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,7 +198,7 @@ pub mod class_prelude {
 }
 
 fn _ensure_sync() {
-    use crate::bus::{PollResult, UsbBus, UsbBusAllocator};
+    use crate::bus::PollResult;
     use crate::class_prelude::*;
 
     struct DummyBus<'a> {


### PR DESCRIPTION
In some usecases it is desirable to select a lower revision of the USB standard (eg when a KVM between the device and the host does not handle usb 2.1 very well).

This allows a device to use a different usb revision (choices limited by an enum).