### PR TITLE
modify `StringIndex` and `.iad()`

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -334,9 +334,9 @@ impl From<InterfaceNumber> for u8 {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct StringIndex(u8);
 
-impl StringIndex {
-    pub(crate) fn new(index: u8) -> StringIndex {
-        StringIndex(index)
+impl From<u8> for StringIndex {
+    fn from(i: u8) -> StringIndex {
+        StringIndex(i)
     }
 }
 

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -185,10 +185,13 @@ impl DescriptorWriter<'_> {
         function_class: u8,
         function_sub_class: u8,
         function_protocol: u8,
+        function_string: Option<StringIndex>,
     ) -> Result<()> {
         if !self.write_iads {
             return Ok(());
         }
+
+        let str_index = function_string.map_or(0, Into::into);
 
         self.write(
             descriptor_type::IAD,
@@ -198,7 +201,7 @@ impl DescriptorWriter<'_> {
                 function_class,
                 function_sub_class,
                 function_protocol,
-                0,
+                str_index,
             ],
         )?;
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,4 +1,4 @@
-use crate::bus::{InterfaceNumber, PollResult, StringIndex, UsbBus, UsbBusAllocator};
+use crate::bus::{InterfaceNumber, PollResult, UsbBus, UsbBusAllocator};
 use crate::class::{ControlIn, ControlOut, UsbClass};
 use crate::control;
 use crate::control_pipe::ControlPipe;
@@ -558,12 +558,12 @@ impl<B: UsbBus> UsbDevice<'_, B> {
                         2 => config.product,
                         3 => config.serial_number,
                         _ => {
-                            let index = StringIndex::new(index);
+                            let str_index = index.into();
                             let lang_id = req.index;
 
                             classes
                                 .iter()
-                                .filter_map(|cls| cls.get_string(index, lang_id))
+                                .filter_map(|cls| cls.get_string(str_index, lang_id))
                                 .next()
                         }
                     };


### PR DESCRIPTION
impl `u8` to `StringIndex`, remove `StringIndex::new()`, pop `StringIndex` for `.iad()`

such that user can define interface/iad name easily.