### PR TITLE
Add copy and eq to UsbError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 * `EndpointType` enum now has fields for isochronous synchronization and usage ([#60](https://github.com/rust-embedded-community/usb-device/pull/60)).
 * `descriptor_type::STRING` of `fn get_descriptor()` will send the LANGIDs supported by device, and respond STRING Request with specified LANGID. ([#122](https://github.com/rust-embedded-community/usb-device/pull/122))
+* `UsbError` is now copyable and comparable ([#127](https://github.com/rust-embedded-community/usb-device/pull/127))
 
 ## [0.2.9] - 2022-08-02
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 #![warn(missing_docs)]
 
 /// A USB stack error.
-#[derive(Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum UsbError {
     /// An operation would block because the device is currently busy or there is no data available.


### PR DESCRIPTION
`UsbError` is as primitive as it gets, and there are situations where the error has to be duplicated (for example to put it in an error event in a non-blocking queue).

Unless there are grand plans for the `UsbError` enum that will add references to data in the future, it would help me to add `Clone`. The other ones are mostly suggestions based on best practices.