### PR TITLE
Fixing an issue with windows device enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+* Fixed a defect where enumeration may fail due to timing-related issues ([#128](https://github.com/rust-embedded-community/usb-device/issues/128))
+
 ### Added
 * New enums and allocators for Isochronous endpoints ([#60](https://github.com/rust-embedded-community/usb-device/pull/60)).
 * Ability to select USB revision ([#116](https://github.com/rust-embedded-community/usb-device/pull/116)).

--- a/src/control_pipe.rs
+++ b/src/control_pipe.rs
@@ -191,6 +191,11 @@ impl<B: UsbBus> ControlPipe<'_, B> {
                 self.state = ControlState::Idle;
                 return true;
             }
+            ControlState::Idle => {
+                // If we received a message on EP0 while sending the last portion of an IN
+                // transfer, we may have already transitioned to IDLE without getting the last
+                // IN-complete status. Just ignore this indication.
+            }
             _ => {
                 // Unexpected IN packet
                 self.set_error();


### PR DESCRIPTION
Fixes #128 by updating the library to ignore `ep_in_status` on the EP0 control pipe when in the `Idle` state.

If the device gets a zero-length-packet while transmitting the last portion of an EP0-IN transmission, it will internally transition to the `Idle` state immediately and essentially "forget" that it just sent an EP0-IN packet, so it was erroring when getting an indication that this packet successfully transmitted.