### PR TITLE
Refactoring language management for simplicity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Breaking
 * Acess numeric form of `EndpointType` variants now require a `.to_bm_attributes()`. ([#60](https://github.com/rust-embedded-community/usb-device/pull/60))
 * `DescriptorWriter::iad()` now requires a `Option<StringIndex>` to optionally specify a string for describing the function ([#121](https://github.com/rust-embedded-community/usb-device/pull/121))
-* `.manufacturer()`, `.product()` and `.serial_number()` of `UsbDeviceBuilder` now require `&[&str]` to specify strings match with each LANGIDs supported by device. ([#122](https://github.com/rust-embedded-community/usb-device/pull/122))
+* `.manufacturer()`, `.product()` and `.serial_number()` of `UsbDeviceBuilder` are now replaced with the `strings()` function that accepts a `StringDescriptor` list to allow multilanguage support ([#122](https://github.com/rust-embedded-community/usb-device/pull/122))
+* Various methods of the `UsbDeviceBuilder` now return `Result<>` types instead of internally panicking.
 
 ### Changed
 * `EndpointType` enum now has fields for isochronous synchronization and usage ([#60](https://github.com/rust-embedded-community/usb-device/pull/60)).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/mvirkkunen/usb-device"
 defmt = { version = "0.3", optional = true }
 portable-atomic = { version = "1.2.0", default-features = false }
 num_enum = { version = "0.6.1", default-features = false }
+heapless = "0.7"
 
 [dev-dependencies]
 rusb = "0.9.1"

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -116,11 +116,29 @@ impl DescriptorWriter<'_> {
                 config.product_id as u8,
                 (config.product_id >> 8) as u8, // idProduct
                 config.device_release as u8,
-                (config.device_release >> 8) as u8,    // bcdDevice
-                config.manufacturer.map_or(0, |_| 1),  // iManufacturer
-                config.product.map_or(0, |_| 2),       // iProduct
-                config.serial_number.map_or(0, |_| 3), // iSerialNumber
-                1,                                     // bNumConfigurations
+                (config.device_release >> 8) as u8, // bcdDevice
+                config.string_descriptors.first().map_or(0, |lang| {
+                    if lang.manufacturer.is_some() {
+                        1
+                    } else {
+                        0
+                    }
+                }),
+                config.string_descriptors.first().map_or(0, |lang| {
+                    if lang.product.is_some() {
+                        2
+                    } else {
+                        0
+                    }
+                }),
+                config.string_descriptors.first().map_or(0, |lang| {
+                    if lang.serial.is_some() {
+                        3
+                    } else {
+                        0
+                    }
+                }),
+                1, // bNumConfigurations
             ],
         )
     }

--- a/src/descriptor/lang_id.rs
+++ b/src/descriptor/lang_id.rs
@@ -15,7 +15,7 @@ impl From<LangID> for u16 {
 }
 
 #[allow(missing_docs)]
-#[derive(Clone, Copy, PartialEq, TryFromPrimitive)]
+#[derive(Clone, Copy, PartialEq, Debug, TryFromPrimitive)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u16)]
 pub enum LangID {

--- a/src/device.rs
+++ b/src/device.rs
@@ -593,7 +593,6 @@ impl<B: UsbBus> UsbDevice<'_, B> {
                                 2 => lang.product,
                                 3 => lang.serial,
                                 _ => unreachable!(),
-
                             }
                         }
                         _ => {

--- a/src/device_builder.rs
+++ b/src/device_builder.rs
@@ -169,7 +169,6 @@ impl<'a, B: UsbBus> UsbDeviceBuilder<'a, B> {
             heapless::Vec::from_slice(descriptors).map_err(|_| BuilderError::TooManyLanguages)?;
 
         Ok(self)
-
     }
 
     /// Sets the maximum packet size in bytes for the control endpoint 0.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,8 @@ pub mod device;
 /// Creating USB descriptors
 pub mod descriptor;
 
+pub use descriptor::lang_id::LangID;
+
 /// Test USB class for testing USB driver implementations. Peripheral driver implementations should
 /// include an example called "test_class" that creates a device with this class to enable the
 /// driver to be tested with the test_class_host example in this crate.

--- a/src/test_class.rs
+++ b/src/test_class.rs
@@ -2,7 +2,7 @@
 
 use crate::class_prelude::*;
 use crate::descriptor::lang_id::LangID;
-use crate::device::{UsbDevice, UsbDeviceBuilder, UsbVidPid};
+use crate::device::{StringDescriptors, UsbDevice, UsbDeviceBuilder, UsbVidPid};
 use crate::Result;
 use core::cmp;
 
@@ -113,10 +113,13 @@ impl<B: UsbBus> TestClass<'_, B> {
         usb_bus: &'a UsbBusAllocator<B>,
     ) -> UsbDeviceBuilder<'a, B> {
         UsbDeviceBuilder::new(usb_bus, UsbVidPid(VID, PID))
-            .manufacturer(&[MANUFACTURER])
-            .product(&[PRODUCT])
-            .serial_number(&[SERIAL_NUMBER])
+            .strings(&[StringDescriptors::default()
+                .manufacturer(MANUFACTURER)
+                .product(PRODUCT)
+                .serial_number(SERIAL_NUMBER)])
+            .unwrap()
             .max_packet_size_0(sizes::CONTROL_ENDPOINT)
+            .unwrap()
     }
 
     /// Must be called after polling the UsbDevice.


### PR DESCRIPTION
This PR builds on #122 by unifying strings under a single `StringDescriptors` structure to keep things organized a little differently. This eases usage on the end-user, as previously the borrowed slices had to be `&'static` borrows, which complicated the construction when i.e. a serial number was read from EEPROM or some other source.