### PR TITLE
Release `usb-device` 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.0] - 2023-11-02
 
 ### Fixed
 * Fixed a defect where enumeration may fail due to timing-related issues ([#128](https://github.com/rust-embedded-community/usb-device/issues/128))
@@ -59,7 +59,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 This is the initial release to crates.io.
 
-[Unreleased]: https://github.com/rust-embedded-community/usb-device/compare/v0.2.9...HEAD
+[Unreleased]: https://github.com/rust-embedded-community/usb-device/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/rust-embedded-community/usb-device/compare/v0.2.9...v0.3.0
 [0.2.9]: https://github.com/rust-embedded-community/usb-device/compare/v0.2.8...v0.2.9
 [0.2.8]: https://github.com/rust-embedded-community/usb-device/compare/v0.2.7...v0.2.8
 [0.2.7]: https://github.com/rust-embedded-community/usb-device/compare/v0.2.6...v0.2.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [0.3.0] - 2023-11-02
+## [0.3.0] - 2023-11-13
 
 ### Fixed
 * Fixed a defect where enumeration may fail due to timing-related issues ([#128](https://github.com/rust-embedded-community/usb-device/issues/128))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usb-device"
 description = "Experimental device-side USB stack for embedded devices."
-version = "0.2.9"
+version = "0.3.0"
 edition = "2018"
 readme = "README.md"
 keywords = ["no-std", "embedded", "usb"]


### PR DESCRIPTION
This PR prepares for a release of usb-device 0.3.0 - I've tested these updates on Stabilizer with a patched dependency chain and I've got PRs ready for a few different crates to update the API.

cc @ithinuel, @jordens