### PR TITLE
Provide `LangID` via preludes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+* `LangID` in `prelude` and `class_prelude`, `StringDescriptors` in `prelude`
+
 ## [0.3.0] - 2023-11-13
 
 ### Fixed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,7 +182,10 @@ mod device_builder;
 
 /// Prelude for device implementors.
 pub mod prelude {
-    pub use crate::device::{UsbDevice, UsbDeviceBuilder, UsbDeviceState, UsbVidPid};
+    pub use crate::device::{
+        StringDescriptors, UsbDevice, UsbDeviceBuilder, UsbDeviceState, UsbVidPid,
+    };
+    pub use crate::LangID;
     pub use crate::UsbError;
 }
 
@@ -196,6 +199,7 @@ pub mod class_prelude {
         EndpointAddress, EndpointIn, EndpointOut, EndpointType, IsochronousSynchronizationType,
         IsochronousUsageType,
     };
+    pub use crate::LangID;
     pub use crate::UsbError;
 }
 


### PR DESCRIPTION
It seems like most uses of usb-device now require the LangID enum, so this PR adds it to the preludes.