### PR TITLE
Documentation updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.3.1] - 2023-11-15
+
 ### Added
 * `BuilderError`, `LangID`, `StringDescriptors` now in `prelude`
 * `LangID` now in `class_prelude`
+
+### Changed
+* Updated documentation, including example code
 
 ## [0.3.0] - 2023-11-13
 
@@ -66,7 +71,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 This is the initial release to crates.io.
 
-[Unreleased]: https://github.com/rust-embedded-community/usb-device/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/rust-embedded-community/usb-device/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/rust-embedded-community/usb-device/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/rust-embedded-community/usb-device/compare/v0.2.9...v0.3.0
 [0.2.9]: https://github.com/rust-embedded-community/usb-device/compare/v0.2.8...v0.2.9
 [0.2.8]: https://github.com/rust-embedded-community/usb-device/compare/v0.2.7...v0.2.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-* `LangID` in `prelude` and `class_prelude`, `StringDescriptors` in `prelude`
+* `BuilderError`, `LangID`, `StringDescriptors` now in `prelude`
+* `LangID` now in `class_prelude`
 
 ## [0.3.0] - 2023-11-13
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "usb-device"
-description = "Experimental device-side USB stack for embedded devices."
-version = "0.3.0"
+description = "USB stack for embedded devices."
+version = "0.3.1"
 edition = "2018"
 readme = "README.md"
 keywords = ["no-std", "embedded", "usb"]
 license = "MIT"
 authors = ["Matti Virkkunen <mvirkkunen@gmail.com>"]
-repository = "https://github.com/mvirkkunen/usb-device"
+repository = "https://github.com/rust-embedded-community/usb-device"
 
 [dependencies]
 defmt = { version = "0.3", optional = true }

--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 usb-device
 ==========
 
-Experimental device-side USB stack for embedded devices in Rust.
-
-This crate is still under development and should not be considered production ready or even USB
-compliant.
+USB stack for embedded devices in Rust.
 
 The UsbDevice object represents a composite USB device and is the most important object for
 application implementors. The UsbDevice combines a number of UsbClasses (either custom ones, or
@@ -39,7 +36,7 @@ Class crates
 
 * [usbd-hid](https://github.com/twitchyliquid64/usbd-hid) [![Crates.io](https://img.shields.io/crates/v/usbd-hid.svg)](https://crates.io/crates/usbd-hid) - HID class
 * [usbd-human-device-interface](https://github.com/dlkj/usbd-human-interface-device) [![Crates.io](https://img.shields.io/crates/v/usbd-human-interface-device.svg)](https://crates.io/crates/usbd-human-device-interface) - HID class
-* [usbd-serial](https://github.com/mvirkkunen/usbd-serial) [![Crates.io](https://img.shields.io/crates/v/usbd-serial.svg)](https://crates.io/crates/usbd-serial) - CDC-ACM serial port class
+* [usbd-serial](https://github.com/rust-embedded-community/usbd-serial) [![Crates.io](https://img.shields.io/crates/v/usbd-serial.svg)](https://crates.io/crates/usbd-serial) - CDC-ACM serial port class
 * [usbd-storage](https://github.com/apohrebniak/usbd-storage) [![Crates.io](https://img.shields.io/crates/v/usbd-storage.svg)](https://crates.io/crates/usbd-storage) - (Experimental) Mass storage port class
 * [usbd-dfu](https://github.com/vitalyvb/usbd-dfu) [![Crates.io](https://img.shields.io/crates/v/usbd-dfu.svg)](https://crates.io/crates/usbd-dfu) - Device Firmware Upgrade class
 * [usbd-picotool-reset](https://github.com/ithinuel/usbd-picotool-reset) [![Crates.io](https://img.shields.io/crates/v/usbd-picotool-reset.svg)](https://crates.io/crates/usbd-picotool-reset) - picotool-reset class

--- a/src/device_builder.rs
+++ b/src/device_builder.rs
@@ -24,9 +24,13 @@ macro_rules! builder_fields {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
+/// Error type for the USB device builder
 pub enum BuilderError {
+    /// String descriptors were provided in more languages than are supported
     TooManyLanguages,
+    /// Control endpoint can only be 8, 16, 32, or 64 byte max packet size
     InvalidPacketSize,
+    /// Configuration specifies higher USB power draw than allowed
     PowerTooHigh,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,7 @@ pub mod prelude {
     pub use crate::device::{
         StringDescriptors, UsbDevice, UsbDeviceBuilder, UsbDeviceState, UsbVidPid,
     };
+    pub use crate::device_builder::BuilderError;
     pub use crate::LangID;
     pub use crate::UsbError;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,9 @@ pub mod endpoint;
 /// // product name. If using an existing class, remember to check the class crate documentation
 /// // for correct values.
 /// let mut usb_dev = UsbDeviceBuilder::new(&usb_bus, UsbVidPid(0x5824, 0x27dd))
-///     .product(&["Serial port"])
+///     .strings(&[StringDescriptors::new(LangID::EN)
+///         .product("Serial port")])
+///         .expect("Failed to set strings")
 ///     .device_class(usb_serial::DEVICE_CLASS)
 ///     .build();
 ///


### PR DESCRIPTION
If https://github.com/rust-embedded-community/usb-device/pull/133 is accepted, this should have the explicit `use` for `LangID` removed from the example code.