### PR TITLE
Update dependecies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ repository = "https://github.com/rust-embedded-community/usb-device"
 [dependencies]
 defmt = { version = "0.3", optional = true }
 portable-atomic = { version = "1.2.0", default-features = false }
-num_enum = { version = "0.6.1", default-features = false }
-heapless = "0.7"
+num_enum = { version = "0.7.1", default-features = false }
+heapless = "0.8"
 
 [dev-dependencies]
 rusb = "0.9.1"


### PR DESCRIPTION
This fixes an issue, with `proc-macro2` in a minimal version build: `cargo +nightly update -Z minimal-versions`

Found out at https://github.com/stm32-rs/stm32f3xx-hal/actions/runs/7016287690/job/19087185399?pr=349, which pulls proc-macro `v1.0.55`

(this crate might however not be the cause of this issue)

`num_enum_derive` has a newer version, which fixes the issue https://github.com/illicitonion/num_enum/blob/a80fa1ef9d1c23995650e9446b1b0721289a2cbd/num_enum_derive/Cargo.toml#L35