### PR TITLE
Make LangID optional on get_string()

### DIFF
--- a/src/class.rs
+++ b/src/class.rs
@@ -44,7 +44,7 @@ pub trait UsbClass<B: UsbBus> {
     /// * `index` - A string index allocated earlier with
     ///   [`UsbAllocator`](crate::bus::UsbBusAllocator).
     /// * `lang_id` - The language ID for the string to retrieve.
-    fn get_string(&self, index: StringIndex, lang_id: LangID) -> Option<&str> {
+    fn get_string(&self, index: StringIndex, lang_id: Option<LangID>) -> Option<&str> {
         let _ = (index, lang_id);
         None
     }

--- a/src/class.rs
+++ b/src/class.rs
@@ -43,8 +43,9 @@ pub trait UsbClass<B: UsbBus> {
     ///
     /// * `index` - A string index allocated earlier with
     ///   [`UsbAllocator`](crate::bus::UsbBusAllocator).
-    /// * `lang_id` - The language ID for the string to retrieve.
-    fn get_string(&self, index: StringIndex, lang_id: Option<LangID>) -> Option<&str> {
+    /// * `lang_id` - The language ID for the string to retrieve. If the requested lang_id is not
+    ///   valid it will default to EN_US.
+    fn get_string(&self, index: StringIndex, lang_id: LangID) -> Option<&str> {
         let _ = (index, lang_id);
         None
     }

--- a/src/device.rs
+++ b/src/device.rs
@@ -563,25 +563,21 @@ impl<B: UsbBus> UsbDevice<'_, B> {
 
                 // rest STRING Requests
                 _ => {
-                    let lang_id = LangID::try_from(req.index);
+                    let lang_id = match LangID::try_from(req.index) {
+                        Err(_err) => {
+                            #[cfg(feature = "defmt")]
+                            defmt::warn!(
+                                "Receive unknown LANGID {:#06X}, default to EN_US",
+                                _err.number
+                            );
+                            LangID::EN_US
+                        }
 
+                        Ok(req_lang_id) => req_lang_id,
+                    };
                     let string = match index {
                         // Manufacturer, product, and serial are handled directly here.
                         1..=3 => {
-                            let lang_id = match lang_id {
-                                Err(_err) => {
-                                    #[cfg(feature = "defmt")]
-                                    defmt::warn!(
-                                        "Receive unknown LANGID {:#06X}, reject the request",
-                                        _err.number
-                                    );
-                                    xfer.reject().ok();
-                                    return;
-                                }
-
-                                Ok(req_lang_id) => req_lang_id,
-                            };
-
                             let Some(lang) = config
                                 .string_descriptors
                                 .iter()
@@ -602,7 +598,7 @@ impl<B: UsbBus> UsbDevice<'_, B> {
                             let index = StringIndex::new(index);
                             classes
                                 .iter()
-                                .find_map(|cls| cls.get_string(index, lang_id.ok()))
+                                .find_map(|cls| cls.get_string(index, lang_id))
                         }
                     };
 

--- a/src/test_class.rs
+++ b/src/test_class.rs
@@ -232,8 +232,8 @@ impl<B: UsbBus> UsbClass<B> for TestClass<'_, B> {
         Ok(())
     }
 
-    fn get_string(&self, index: StringIndex, lang_id: LangID) -> Option<&str> {
-        if lang_id == LangID::EN_US {
+    fn get_string(&self, index: StringIndex, lang_id: Option<LangID>) -> Option<&str> {
+        if lang_id == Some(LangID::EN_US) {
             if index == self.custom_string {
                 return Some(CUSTOM_STRING);
             } else if index == self.interface_string {

--- a/src/test_class.rs
+++ b/src/test_class.rs
@@ -232,8 +232,8 @@ impl<B: UsbBus> UsbClass<B> for TestClass<'_, B> {
         Ok(())
     }
 
-    fn get_string(&self, index: StringIndex, lang_id: Option<LangID>) -> Option<&str> {
-        if lang_id == Some(LangID::EN_US) {
+    fn get_string(&self, index: StringIndex, lang_id: LangID) -> Option<&str> {
+        if lang_id == LangID::EN_US {
             if index == self.custom_string {
                 return Some(CUSTOM_STRING);
             } else if index == self.interface_string {


### PR DESCRIPTION
I've been playing around with the [Microsoft OS String Descriptors](https://github.com/pbatard/libwdi/wiki/WCID-Devices#microsoft-os-string-descriptor) (specifically to get the winusb driver installed on my device) and everything was working fine on 0.2.9 but the update to 0.3.0 (#122) introduced a behavior difference. 

The change in #122 requires that  `req.index` be a valid lang id, if not, it exits early and doesn't call the `get_string` method. 

I also thought lang id could be set to a default in order to not get a breaking change but I think it obscures that LangId might not be set for all requests? 

Any thoughts appreciated. I'm just dabbling on embedded stuff so I could be missing something.