### PR TITLE
Adding USB tracing, fixing further enumeration issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+* A new `log` feature can be enabled to provide logging and tracing information about the USB
+interface.
+
 ### Changed
 * Invalid LangIDs will default to `EN_US`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ interface.
 
 ### Changed
 * Invalid LangIDs will default to `EN_US`
+* Changed handling of EP0 state to eliminate unexpected issues with device enumeration
 
 ## [0.3.1] - 2023-11-15
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ defmt = { version = "0.3", optional = true }
 portable-atomic = { version = "1.2.0", default-features = false }
 num_enum = { version = "0.7.1", default-features = false }
 heapless = "0.8"
+log = { version = "0.4", default-features = false, optional = true}
 
 [dev-dependencies]
 rusb = "0.9.1"
@@ -22,6 +23,9 @@ rand = "0.8.5"
 [features]
 # Use a 256 byte buffer for control transfers instead of 128.
 control-buffer-256 = []
+
+# Enable logging and tracing via the `log` crate
+log = ["dep:log"]
 
 # Use larger endpoint buffers for highspeed operation (default fullspeed)
 #

--- a/src/control_pipe.rs
+++ b/src/control_pipe.rs
@@ -144,7 +144,10 @@ impl<B: UsbBus> ControlPipe<'_, B> {
                     }
                 };
 
-                usb_trace!("Read {count} bytes on EP0-OUT: {:?}", &self.buf[i..(i + count)]);
+                usb_trace!(
+                    "Read {count} bytes on EP0-OUT: {:?}",
+                    &self.buf[i..(i + count)]
+                );
                 self.i += count;
 
                 if self.i >= self.len {
@@ -254,8 +257,8 @@ impl<B: UsbBus> ControlPipe<'_, B> {
             ControlState::CompleteOut => {}
             _ => {
                 usb_debug!("Cannot ACK, invalid state: {:?}", self.state);
-                return Err(UsbError::InvalidState)
-            },
+                return Err(UsbError::InvalidState);
+            }
         };
 
         let _ = self.ep_in.write(&[]);
@@ -269,7 +272,7 @@ impl<B: UsbBus> ControlPipe<'_, B> {
             _ => {
                 usb_debug!("EP0-IN cannot ACK, invalid state: {:?}", self.state);
                 return Err(UsbError::InvalidState);
-            },
+            }
         };
 
         let len = f(&mut self.buf[..])?;

--- a/src/control_pipe.rs
+++ b/src/control_pipe.rs
@@ -70,7 +70,7 @@ impl<B: UsbBus> ControlPipe<'_, B> {
     pub fn handle_setup(&mut self) -> Option<Request> {
         let count = match self.ep_out.read(&mut self.buf[..]) {
             Ok(count) => {
-                usb_trace!("Read {count} bytes on EP0-OUT: {:?}", &self.buf[..count]);
+                usb_trace!("Read {} bytes on EP0-OUT: {:?}", count, &self.buf[..count]);
                 count
             }
             Err(UsbError::WouldBlock) => return None,
@@ -91,7 +91,7 @@ impl<B: UsbBus> ControlPipe<'_, B> {
         // a stalled state.
         self.ep_out.unstall();
 
-        usb_debug!("EP0 request received: {req:?}");
+        usb_debug!("EP0 request received: {:?}", req);
 
         /*sprintln!("SETUP {:?} {:?} {:?} req:{} val:{} idx:{} len:{} {:?}",
         req.direction, req.request_type, req.recipient,
@@ -145,13 +145,14 @@ impl<B: UsbBus> ControlPipe<'_, B> {
                 };
 
                 usb_trace!(
-                    "Read {count} bytes on EP0-OUT: {:?}",
+                    "Read {} bytes on EP0-OUT: {:?}",
+                    count,
                     &self.buf[i..(i + count)]
                 );
                 self.i += count;
 
                 if self.i >= self.len {
-                    usb_debug!("Request OUT complete: {req:?}");
+                    usb_debug!("Request OUT complete: {:?}", req);
                     self.state = ControlState::CompleteOut;
                     return Some(req);
                 }
@@ -232,7 +233,7 @@ impl<B: UsbBus> ControlPipe<'_, B> {
             // There isn't much we can do if the write fails, except to wait for another poll or for
             // the host to resend the request.
             Err(_err) => {
-                usb_debug!("Failed to write EP0: {_err:?}");
+                usb_debug!("Failed to write EP0: {:?}", _err);
                 return;
             }
         };

--- a/src/device.rs
+++ b/src/device.rs
@@ -244,8 +244,7 @@ impl<B: UsbBus> UsbDevice<'_, B> {
 
                                 self.device_state = UsbDeviceState::Addressed;
                             }
-
-                        },
+                        }
 
                         _ => (),
                     };

--- a/src/device.rs
+++ b/src/device.rs
@@ -259,21 +259,21 @@ impl<B: UsbBus> UsbDevice<'_, B> {
                     for i in 1..MAX_ENDPOINTS {
                         if (ep_setup & bit) != 0 {
                             for cls in classes.iter_mut() {
-                                usb_trace!("Handling EP{i}-SETUP");
+                                usb_trace!("Handling EP{}-SETUP", i);
                                 cls.endpoint_setup(EndpointAddress::from_parts(
                                     i,
                                     UsbDirection::Out,
                                 ));
                             }
                         } else if (ep_out & bit) != 0 {
-                            usb_trace!("Handling EP{i}-OUT");
+                            usb_trace!("Handling EP{}-OUT", i);
                             for cls in classes.iter_mut() {
                                 cls.endpoint_out(EndpointAddress::from_parts(i, UsbDirection::Out));
                             }
                         }
 
                         if (ep_in_complete & bit) != 0 {
-                            usb_trace!("Handling EP{i}-IN");
+                            usb_trace!("Handling EP{}-IN", i);
                             for cls in classes.iter_mut() {
                                 cls.endpoint_in_complete(EndpointAddress::from_parts(
                                     i,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,9 @@
 #![no_std]
 #![warn(missing_docs)]
 
+#[macro_use]
+mod macros;
+
 /// A USB stack error.
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -5,7 +5,7 @@ macro_rules! usb_log {
 }
 
 #[cfg(feature = "defmt")]
-macro_rules! net_log {
+macro_rules! usb_log {
     (trace, $($arg:expr),*) => { defmt::trace!($($arg),*) };
     (debug, $($arg:expr),*) => { defmt::debug!($($arg),*) };
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,24 @@
+#[cfg(feature = "log")]
+macro_rules! usb_log {
+    (trace, $($arg:expr),*) => { log::trace!($($arg),*) };
+    (debug, $($arg:expr),*) => { log::trace!($($arg),*) };
+}
+
+#[cfg(feature = "defmt")]
+macro_rules! net_log {
+    (trace, $($arg:expr),*) => { defmt::trace!($($arg),*) };
+    (debug, $($arg:expr),*) => { defmt::debug!($($arg),*) };
+}
+
+#[cfg(not(any(feature = "log", feature = "defmt")))]
+macro_rules! usb_log {
+    ($level:ident, $($arg:expr),*) => {{ $( let _ = $arg; )* }}
+}
+
+macro_rules! usb_trace {
+    ($($arg:expr),*) => (usb_log!(trace, $($arg),*));
+}
+
+macro_rules! usb_debug {
+    ($($arg:expr),*) => (usb_log!(debug, $($arg),*));
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "log")]
+#[cfg(all(feature = "log", not(feature = "defmt")))]
 macro_rules! usb_log {
     (trace, $($arg:expr),*) => { log::trace!($($arg),*) };
     (debug, $($arg:expr),*) => { log::trace!($($arg),*) };


### PR DESCRIPTION
This PR does a few things:
1. Adds in a new logging feature to make it easy to trace USB debug issues in the future (I've written this a few times, and figured it would be useful as a general feature instead)
2. Removed the `set_error()` calls when processing a SETUP packet. We are not allowed to error in this state and should simply ignore the SETUP packet instead.
3. Changed the handling of EP0-IN-complete tokens. We were being pretty jumpy with getting these tokens in unexpected states, however this is simply an indication that a packet transmission completed. We may have updated state internally and lost track of what we sent. As such, I've updated it such that we just ignore these tokens if we don't need them in our current state instead of stalling the control pipe, as this isn't really an error.

This effectively reverts https://github.com/rust-embedded-community/usb-device/pull/41, as further updates to EP0 control pipe handling make it unnecessary. Reversion of this PR prevents us from sending more data in a control transfer than is expected, since the host may have initiated the STATUS phase of the transfer already.