### PR TITLE
Handling `Result`s throughout the crate

### DIFF
--- a/src/control_pipe.rs
+++ b/src/control_pipe.rs
@@ -136,10 +136,11 @@ impl<B: UsbBus> ControlPipe<'_, B> {
                 let count = match self.ep_out.read(&mut self.buf[i..]) {
                     Ok(count) => count,
                     Err(UsbError::WouldBlock) => return Ok(None),
-                    Err(_) => {
+                    Err(_err) => {
                         // Failed to read or buffer overflow (overflow is only possible if the host
                         // sends more data than it indicated in the SETUP request)
                         self.set_error();
+                        usb_debug!("Failed EP0 read: {:?}", _err);
                         return Ok(None);
                     }
                 };

--- a/src/control_pipe.rs
+++ b/src/control_pipe.rs
@@ -139,8 +139,8 @@ impl<B: UsbBus> ControlPipe<'_, B> {
                     Err(_err) => {
                         // Failed to read or buffer overflow (overflow is only possible if the host
                         // sends more data than it indicated in the SETUP request)
-                        self.set_error();
                         usb_debug!("Failed EP0 read: {:?}", _err);
+                        self.set_error();
                         return Ok(None);
                     }
                 };

--- a/src/device.rs
+++ b/src/device.rs
@@ -218,7 +218,7 @@ impl<B: UsbBus> UsbDevice<'_, B> {
                             Ok(req) => req,
                             Err(_err) => {
                                 // TODO: Propagate error out of `poll()`
-                                usb_debug!("Failed to handle EP0: {}", _err);
+                                usb_debug!("Failed to handle EP0: {:?}", _err);
                                 None
                             }
                         }
@@ -230,7 +230,7 @@ impl<B: UsbBus> UsbDevice<'_, B> {
                         Some(req) if req.direction == UsbDirection::In => {
                             if let Err(_err) = self.control_in(classes, req) {
                                 // TODO: Propagate error out of `poll()`
-                                usb_debug!("Failed to handle control request: {}", _err);
+                                usb_debug!("Failed to handle control request: {:?}", _err);
                             }
                         }
                         Some(req) if req.direction == UsbDirection::Out => {
@@ -248,7 +248,7 @@ impl<B: UsbBus> UsbDevice<'_, B> {
                                 Err(_err) => {
                                     // TODO: Propagate this out of `poll()`
                                     usb_debug!(
-                                        "Failed to process control-input complete: {}",
+                                        "Failed to process control-input complete: {:?}",
                                         _err
                                     );
                                     false

--- a/src/device.rs
+++ b/src/device.rs
@@ -243,7 +243,17 @@ impl<B: UsbBus> UsbDevice<'_, B> {
                             // phases of the control transfer. If we just got a SETUP packet or
                             // an OUT token, we can safely ignore the IN-COMPLETE indication and
                             // continue with the next transfer.
-                            let completed = self.control.handle_in_complete();
+                            let completed = match self.control.handle_in_complete() {
+                                Ok(completed) => completed,
+                                Err(_err) => {
+                                    // TODO: Propagate this out of `poll()`
+                                    usb_debug!(
+                                        "Failed to process control-input complete: {}",
+                                        _err
+                                    );
+                                    false
+                                }
+                            };
 
                             if !B::QUIRK_SET_ADDRESS_BEFORE_STATUS
                                 && completed

--- a/src/device.rs
+++ b/src/device.rs
@@ -218,7 +218,7 @@ impl<B: UsbBus> UsbDevice<'_, B> {
                             Ok(req) => req,
                             Err(_err) => {
                                 // TODO: Propagate error out of `poll()`
-                                usb_debug!("Failed to handle EP0: {_err}");
+                                usb_debug!("Failed to handle EP0: {}", _err);
                                 None
                             }
                         }
@@ -230,7 +230,7 @@ impl<B: UsbBus> UsbDevice<'_, B> {
                         Some(req) if req.direction == UsbDirection::In => {
                             if let Err(_err) = self.control_in(classes, req) {
                                 // TODO: Propagate error out of `poll()`
-                                usb_debug!("Failed to handle control request: {_err}");
+                                usb_debug!("Failed to handle control request: {}", _err);
                             }
                         }
                         Some(req) if req.direction == UsbDirection::Out => {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,7 +1,7 @@
 #[cfg(all(feature = "log", not(feature = "defmt")))]
 macro_rules! usb_log {
     (trace, $($arg:expr),*) => { log::trace!($($arg),*) };
-    (debug, $($arg:expr),*) => { log::trace!($($arg),*) };
+    (debug, $($arg:expr),*) => { log::debug!($($arg),*) };
 }
 
 #[cfg(feature = "defmt")]


### PR DESCRIPTION
Fixes #113 by handling all the various `Result<>` types and propogating them upwards to `poll()`. For now, they are simply logged. In the future, it could be helpful to push these outwards and have `poll()` return the `Result<>` type, however I'm hesitant to introduce a breaking API change right now. I'll spawn an issue for this.

This also fixes #58 by propagating the errors described to the new log macros.