### PR TITLE
Restore deriving defmt::Format for LangID when defmt feature is enabled

### DIFF
--- a/src/descriptor/lang_id.rs
+++ b/src/descriptor/lang_id.rs
@@ -2,6 +2,7 @@
 
 #[allow(missing_docs)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct LangID(u16);
 
 impl From<LangID> for u16 {


### PR DESCRIPTION
defmt deriving for LangID was unintentionally removed by pull request #141. Restore it.