### PR TITLE
Preparing for 0.3.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.3.2] - 2024-03-04
+
 ### Added
 * A new `log` feature can be enabled to provide logging and tracing information about the USB
 interface.
@@ -81,7 +83,8 @@ as this was not intended to be used in the public API.
 
 This is the initial release to crates.io.
 
-[Unreleased]: https://github.com/rust-embedded-community/usb-device/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/rust-embedded-community/usb-device/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/rust-embedded-community/usb-device/compare/v0.3.0...v0.3.2
 [0.3.1]: https://github.com/rust-embedded-community/usb-device/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/rust-embedded-community/usb-device/compare/v0.2.9...v0.3.0
 [0.2.9]: https://github.com/rust-embedded-community/usb-device/compare/v0.2.8...v0.2.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@ as this was not intended to be used in the public API.
 This is the initial release to crates.io.
 
 [Unreleased]: https://github.com/rust-embedded-community/usb-device/compare/v0.3.2...HEAD
-[0.3.2]: https://github.com/rust-embedded-community/usb-device/compare/v0.3.0...v0.3.2
+[0.3.2]: https://github.com/rust-embedded-community/usb-device/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/rust-embedded-community/usb-device/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/rust-embedded-community/usb-device/compare/v0.2.9...v0.3.0
 [0.2.9]: https://github.com/rust-embedded-community/usb-device/compare/v0.2.8...v0.2.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [0.3.2] - 2024-03-04
+## [0.3.2] - 2024-03-06
 
 ### Added
 * A new `log` feature can be enabled to provide logging and tracing information about the USB

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usb-device"
 description = "USB stack for embedded devices."
-version = "0.3.1"
+version = "0.3.2"
 edition = "2018"
 readme = "README.md"
 keywords = ["no-std", "embedded", "usb"]


### PR DESCRIPTION
This PR prepares the crate for a 0.3.2 release to get some fixes out. Specifically, this should reduce code size for users and fix issues with Windows enumeration.

I'm going to look at some API updates for a 0.4 release later and want to cut these changes out as a patch before we go down a semver-breaking update again, since there's a lot of downstream dependencies to update as well.