### PR TITLE
Updating poll functions to return results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+* [breaking] The `usb_device::UsbDevice::poll()` function now returns a `Result` type.
+
 ## [0.3.2] - 2024-03-06
 
 ### Added

--- a/src/class.rs
+++ b/src/class.rs
@@ -54,7 +54,9 @@ pub trait UsbClass<B: UsbBus> {
     fn reset(&mut self) {}
 
     /// Called whenever the `UsbDevice` is polled.
-    fn poll(&mut self) {}
+    fn poll(&mut self) -> Result<()> {
+        Ok(())
+    }
 
     /// Called when a control request is received with direction HostToDevice.
     ///


### PR DESCRIPTION
This PR updates the traits to allow `poll()` to return `Result<>` types if needed. I'm unsure if the `UsbClass::poll()` function should return a `Result` or not currently.