### PR TITLE
Feature gate portable atomics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/rust-embedded-community/usb-device"
 
 [dependencies]
 defmt = { version = "0.3", optional = true }
-portable-atomic = { version = "1.2.0", default-features = false }
+portable-atomic = { version = "1.2.0", default-features = false, optional = true }
 heapless = "0.8"
 log = { version = "0.4", default-features = false, optional = true}
 
@@ -20,6 +20,7 @@ rusb = "0.9.1"
 rand = "0.8.5"
 
 [features]
+default = ["portable-atomic"]
 
 # Use larger endpoint buffers for highspeed operation (default fullspeed)
 #
@@ -27,6 +28,7 @@ rand = "0.8.5"
 # TestClass only compliant with high speed mode. It may still manage to be enumerated as a full
 # speed device, but the descriptors will be invalid.
 test-class-high-speed = []
+portable-atomic = ["dep:portable-atomic"]
 
 [[test]]
 name = "test_class_host"

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -6,7 +6,10 @@ use crate::{Result, UsbDirection, UsbError};
 use core::cell::RefCell;
 use core::mem;
 use core::ptr;
+#[cfg(feature = "portable-atomic")]
 use portable_atomic::{AtomicPtr, Ordering};
+#[cfg(not(feature = "portable-atomic"))]
+use core::sync::atomic::{AtomicPtr, Ordering};
 
 /// A trait for device-specific USB peripherals. Implement this to add support for a new hardware
 /// platform.

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -1,7 +1,10 @@
 use crate::bus::UsbBus;
 use crate::{Result, UsbDirection};
 use core::marker::PhantomData;
+#[cfg(feature = "portable-atomic")]
 use portable_atomic::{AtomicPtr, Ordering};
+#[cfg(not(feature = "portable-atomic"))]
+use core::sync::atomic::{AtomicPtr, Ordering};
 
 /// Trait for endpoint type markers.
 pub trait EndpointDirection {


### PR DESCRIPTION
Allow an opt-out for portable atomics, if the platform has atomic load/store then they aren't necessary