### PR TITLE
Don't require UsbBus to be Sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * [breaking] The control pipe is now provided in the `UsbDeviceBuilder` API to allow for user-provided control
 pipes. This makes it so that control pipes have configurable sizing.
+* Don't require UsbBus to be Sync. If a UsbBus is not Sync, it can still be used to make a UsbDevice, but that UsbDevice will not be Sync (ensuring soundness).
 
 ## [0.3.2] - 2024-03-06
 

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -17,7 +17,7 @@ use portable_atomic::{AtomicPtr, Ordering};
 /// take place before [`enable`](UsbBus::enable) is called. After the bus is enabled, in practice
 /// most access won't mutate the object itself but only endpoint-specific registers and buffers, the
 /// access to which is mostly arbitrated by endpoint handles.
-pub trait UsbBus: Sync + Sized {
+pub trait UsbBus: Sized {
     /// Allocates an endpoint and specified endpoint parameters. This method is called by the device
     /// and class implementations to allocate endpoints, and can only be called before
     /// [`enable`](UsbBus::enable) is called.


### PR DESCRIPTION
### Current behavior:
* UsbBus is Sync --> the resulting UsbDevice is Sync.
* UsbBus is not Sync --> compiler error due to unsatisfied trait bound

### Proposed new behavior:
* UsbBus is Sync --> the resulting UsbDevice is Sync.
* UsbBus is not Sync --> the resulting UsbDevice is *not* Sync

In other words, it is _safe_ to allow a non-Sync UsbBus because Rust will NOT derive Sync for the UsbDevice in this case.

### Why is this useful?
I have a hard-real-time firmware application which uses the USB interface to provide secondary (non-real-time) diagnostics. I poll the UsbDevice in my main loop, while all my other real-time stuff is handled in various interrupts. I do not use USB interrupts and I never access the UsbDevice from an interrupt context.

Unfortunately, making the UsbBus Sync requires the use of critical sections which damage the real-time interrupt timing. Eliminating the critical sections is totally safe in this situation, and solves my timing issues, but doing so means that the UsbBus cannot safely be marked as Sync.

* For more context see https://github.com/stm32-rs/stm32-usbd/issues/32
* For an implemented example of the UsbBus changes for non-Sync usage, see https://github.com/dlaw/stm32-usbd-no-cs
* If accepted, this PR would allow me to eliminate the following *highly unsound* `impl Sync`: https://github.com/dlaw/stm32-usbd-no-cs/commit/7df1814aacca9c82c3d325276f290bdd5afa5696#diff-b7dd6c6dc06c9c5da00a0c048df395e5fed282392d70a222b1d0e34706d9baf3R26