### PR TITLE
Add new read_setup() for control endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+* [breaking] Bus API now has separate `read()` and `read_setup()` methods for OUT and SETUP data.
 * [breaking] The control pipe is now provided in the `UsbDeviceBuilder` API to allow for user-provided control
 pipes. This makes it so that control pipes have configurable sizing.
 * Don't require UsbBus to be Sync. If a UsbBus is not Sync, it can still be used to make a UsbDevice, but that UsbDevice will not be Sync (ensuring soundness).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+* Test case that hard-resets the device and measures the time it takes to re-enumerate.
 * `DummyUsbBus` without functionality to allow examples that actually compile (but not run).
 * Extended `UsbRev` enum with variants for USB 1.0 and 1.1.
 

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -93,6 +93,9 @@ pub trait UsbBus: Sized {
     /// * [`WouldBlock`](crate::UsbError::WouldBlock) - There is no packet to be read. Note that
     ///   this is different from a received zero-length packet, which is valid in USB. A zero-length
     ///   packet will return `Ok(0)`.
+    ///
+    ///   `WouldBlock` is also returned when the endpoint received a SETUP transaction, which can be
+    ///   read through [`read_setup()`](UsbBus::read_setup()).
     /// * [`BufferOverflow`](crate::UsbError::BufferOverflow) - The received packet is too long to
     ///   fit in `buf`. This is generally an error in the class implementation, because the class
     ///   should use a buffer that is large enough for the `max_packet_size` it specified when
@@ -114,14 +117,8 @@ pub trait UsbBus: Sized {
     ///
     /// * [`InvalidEndpoint`](crate::UsbError::InvalidEndpoint) - The `ep_addr` does not point to a
     ///   valid endpoint that was previously allocated with [`UsbBus::alloc_ep`].
-    /// * [`WouldBlock`](crate::UsbError::WouldBlock) - There is no SETUP packet to be read. Note
-    ///   that this is different from a received zero-length packet, which is valid in USB. A
-    ///   zero-length packet will return `Ok(0)`.
-    /// * [`BufferOverflow`](crate::UsbError::BufferOverflow) - The received packet is too long to
-    ///   fit in `buf`. This is generally an error in the class implementation, because the class
-    ///   should use a buffer that is large enough for the `max_packet_size` it specified when
-    ///   allocating the endpoint.
-    fn read_setup(&self, ep_addr: EndpointAddress, buf: &mut [u8]) -> Result<usize>;
+    /// * [`WouldBlock`](crate::UsbError::WouldBlock) - There is no SETUP packet to be read.
+    fn read_setup(&self, ep_addr: EndpointAddress) -> Result<[u8; 8]>;
 
     /// Sets or clears the STALL condition for an endpoint. If the endpoint is an OUT endpoint, it
     /// should be prepared to receive data again.

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -81,8 +81,8 @@ pub trait UsbBus: Sized {
     /// Implementations may also return other errors if applicable.
     fn write(&self, ep_addr: EndpointAddress, buf: &[u8]) -> Result<usize>;
 
-    /// Reads a single packet of data from the specified endpoint and returns the actual length of
-    /// the packet.
+    /// Reads a single packet of OUT data from the specified endpoint and returns the length of the
+    /// packet.
     ///
     /// This should also clear any NAK flags and prepare the endpoint to receive the next packet.
     ///
@@ -97,9 +97,31 @@ pub trait UsbBus: Sized {
     ///   fit in `buf`. This is generally an error in the class implementation, because the class
     ///   should use a buffer that is large enough for the `max_packet_size` it specified when
     ///   allocating the endpoint.
+    /// * [`InvalidState`](crate::UsbError::InvalidState) - The received packet is a SETUP
+    ///   transaction, and needs to be read through [`read_setup()`](UsbBus::read_setup()) instead.
     ///
     /// Implementations may also return other errors if applicable.
     fn read(&self, ep_addr: EndpointAddress, buf: &mut [u8]) -> Result<usize>;
+
+    /// Reads a packet of SETUP data from the specified endpoint, returns the length of the packet
+    ///
+    /// This is a distinct method from [`read()`](UsbBus::read()) because the USB spec states that
+    /// the function (device) must accept the SETUP transaction, which in some implementations can
+    /// result in a SETUP transaction overwriting data from an earlier OUT transaction.  Separate
+    /// read methods allow the control pipe implementation to detect this overwriting.
+    ///
+    /// # Errors
+    ///
+    /// * [`InvalidEndpoint`](crate::UsbError::InvalidEndpoint) - The `ep_addr` does not point to a
+    ///   valid endpoint that was previously allocated with [`UsbBus::alloc_ep`].
+    /// * [`WouldBlock`](crate::UsbError::WouldBlock) - There is no SETUP packet to be read. Note
+    ///   that this is different from a received zero-length packet, which is valid in USB. A
+    ///   zero-length packet will return `Ok(0)`.
+    /// * [`BufferOverflow`](crate::UsbError::BufferOverflow) - The received packet is too long to
+    ///   fit in `buf`. This is generally an error in the class implementation, because the class
+    ///   should use a buffer that is large enough for the `max_packet_size` it specified when
+    ///   allocating the endpoint.
+    fn read_setup(&self, ep_addr: EndpointAddress, buf: &mut [u8]) -> Result<usize>;
 
     /// Sets or clears the STALL condition for an endpoint. If the endpoint is an OUT endpoint, it
     /// should be prepared to receive data again.

--- a/src/class.rs
+++ b/src/class.rs
@@ -8,8 +8,7 @@ use crate::{Result, UsbError};
 
 /// A trait for implementing USB classes.
 ///
-/// All methods are optional callbacks that will be called by
-/// [UsbBus::poll](crate::bus::UsbBus::poll)
+/// All methods are optional callbacks that will be called by [UsbBus::poll]
 pub trait UsbClass<B: UsbBus> {
     /// Called when a GET_DESCRIPTOR request is received for a configuration descriptor. When
     /// called, the implementation should write its interface, endpoint and any extra class

--- a/src/control_pipe.rs
+++ b/src/control_pipe.rs
@@ -65,10 +65,10 @@ impl<B: UsbBus> ControlPipe<'_, B> {
     }
 
     pub fn handle_setup(&mut self) -> Option<Request> {
-        let count = match self.ep_out.read_setup(&mut self.buf[..]) {
-            Ok(count) => {
-                usb_trace!("Read {} bytes on EP0-OUT: {:?}", count, &self.buf[..count]);
-                count
+        let packet = match self.ep_out.read_setup() {
+            Ok(packet) => {
+                usb_trace!("Read SETUP packet on EP0-OUT: {:?}", packet);
+                packet
             }
             Err(UsbError::WouldBlock) => return None,
             Err(_) => {
@@ -76,7 +76,7 @@ impl<B: UsbBus> ControlPipe<'_, B> {
             }
         };
 
-        let req = match Request::parse(&self.buf[0..count]) {
+        let req = match Request::parse(&packet) {
             Ok(req) => req,
             Err(_) => {
                 // Failed to parse SETUP packet. We are supposed to silently ignore this.
@@ -167,7 +167,7 @@ impl<B: UsbBus> ControlPipe<'_, B> {
                 );
                 match self.ep_out.read(&mut []) {
                     Ok(_) => {}
-                    Err(UsbError::InvalidState) => {
+                    Err(UsbError::WouldBlock) => {
                         // Host sent a new SETUP transaction, which may have overwritten the ZLP
                     }
                     Err(err) => {

--- a/src/dummy.rs
+++ b/src/dummy.rs
@@ -56,6 +56,14 @@ impl UsbBus for DummyUsbBus {
         unimplemented!()
     }
 
+    fn read_setup(
+        &self,
+        ep_addr: crate::class_prelude::EndpointAddress,
+        buf: &mut [u8],
+    ) -> crate::Result<usize> {
+        unimplemented!()
+    }
+
     fn reset(&self) {
         unimplemented!()
     }

--- a/src/dummy.rs
+++ b/src/dummy.rs
@@ -59,8 +59,7 @@ impl UsbBus for DummyUsbBus {
     fn read_setup(
         &self,
         ep_addr: crate::class_prelude::EndpointAddress,
-        buf: &mut [u8],
-    ) -> crate::Result<usize> {
+    ) -> crate::Result<[u8; 8]> {
         unimplemented!()
     }
 

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -199,49 +199,56 @@ impl<B: UsbBus> Endpoint<'_, B, In> {
 impl<B: UsbBus> Endpoint<'_, B, Out> {
     /// Reads a single packet of data and returns the length of the packet
     ///
-    /// The buffer should be large enough to fit at least as many bytes as the `max_packet_size`
-    /// specified when allocating the endpoint.
+    /// The buffer should be large enough to fit at least as many bytes as the
+    /// `max_packet_size` specified when allocating the endpoint.
     ///
     /// # Errors
     ///
-    /// Note: USB bus implementation errors are directly passed through, so be prepared to handle
-    /// other errors as well.
+    /// Note: USB bus implementation errors are directly passed through, so be
+    /// prepared to handle other errors as well.
     ///
-    /// * [`WouldBlock`](crate::UsbError::WouldBlock) - There is no packet to be read. Note that
-    ///   this is different from a received zero-length packet, which is valid and significant in
-    ///   USB. A zero-length packet will return `Ok(0)`.
-    /// * [`BufferOverflow`](crate::UsbError::BufferOverflow) - The received packet is too long to
-    ///   fit in `data`. This is generally an error in the class implementation.
-    /// * [`InvalidState`](crate::UsbError::InvalidState) - The received packet is a SETUP
-    ///   transaction, and needs to be read through [`read_setup()`](Endpoint::read_setup())
-    ///   instead.
+    /// * [`WouldBlock`](crate::UsbError::WouldBlock) - There is no OUT packet
+    ///   to be read. Note that this is different from a received zero-length
+    ///   packet, which is valid and significant in USB. A zero-length packet
+    ///   will return `Ok(0)`.
+    ///
+    ///   `WouldBlock` is also returned when the endpoint received a SETUP
+    ///   transaction, which can be read through
+    ///   [`read_setup()`](Endpoint::read_setup()).
+    /// * [`BufferOverflow`](crate::UsbError::BufferOverflow) - The received
+    ///   packet is too long to fit in `data`. This is generally an error in the
+    ///   class implementation.
     pub fn read(&self, data: &mut [u8]) -> Result<usize> {
         self.bus().read(self.address, data)
     }
 
-    /// Reads a single packet of SETUP data and returns the length of the packet
+    /// Reads a single packet of SETUP data and returns it
     ///
-    /// The buffer should be large enough to fit at least as many bytes as the `max_packet_size`
-    /// specified when allocating the endpoint.  See [`UsbBus::read_setup()`] for rationale for two
-    /// distinct read methods.
+    /// USB Spec 2.0 5.5.3 Control Transfer Packet Size Constraints: "A Setup
+    /// packet is always eight bytes."
+    ///
+    /// See [`UsbBus::read_setup()`] for rationale for two distinct read
+    /// methods.
     ///
     /// # Errors
     ///
-    /// Note: USB bus implementation errors are directly passed through, so be prepared to handle
-    /// other errors as well.
+    /// Note: USB bus implementation errors are directly passed through, so be
+    /// prepared to handle other errors as well.
     ///
-    /// * [`WouldBlock`](crate::UsbError::WouldBlock) - There is no packet to be read. Note that
-    ///   this is different from a received zero-length packet, which is valid and significant in
-    ///   USB. A zero-length packet will return `Ok(0)`.
-    /// * [`BufferOverflow`](crate::UsbError::BufferOverflow) - The received packet is too long to
-    ///   fit in `data`. This is generally an error in the class implementation.
-    pub fn read_setup(&self, data: &mut [u8]) -> Result<usize> {
+    /// * [`WouldBlock`](crate::UsbError::WouldBlock) - There is no packet to be
+    ///   read. Note that this is different from a received zero-length packet,
+    ///   which is valid and significant in USB. A zero-length packet will
+    ///   return `Ok(0)`.
+    /// * [`InvalidEndpoint`](crate::UsbError::InvalidEndpoint) - SETUP packets
+    ///   can only be read from Control endpoints, this error is returned if the
+    ///   method is called on any other type endpoint.
+    pub fn read_setup(&self) -> Result<[u8; 8]> {
         // SETUP transactions can only occur on control endpoints
         if self.ep_type != EndpointType::Control {
-            Err(UsbError::InvalidEndpoint)
-        } else {
-            self.bus().read_setup(self.address, data)
+            return Err(UsbError::InvalidEndpoint);
         }
+
+        self.bus().read_setup(self.address)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,6 +258,10 @@ fn _ensure_sync() {
             Err(UsbError::InvalidEndpoint)
         }
 
+        fn read_setup(&self, _ep_addr: EndpointAddress, _buf: &mut [u8]) -> Result<usize> {
+            Err(UsbError::InvalidEndpoint)
+        }
+
         fn set_stalled(&self, _ep_addr: EndpointAddress, _stalled: bool) {}
         fn is_stalled(&self, _ep_addr: EndpointAddress) -> bool {
             false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,7 +258,7 @@ fn _ensure_sync() {
             Err(UsbError::InvalidEndpoint)
         }
 
-        fn read_setup(&self, _ep_addr: EndpointAddress, _buf: &mut [u8]) -> Result<usize> {
+        fn read_setup(&self, _ep_addr: EndpointAddress) -> Result<[u8; 8]> {
             Err(UsbError::InvalidEndpoint)
         }
 

--- a/src/test_class.rs
+++ b/src/test_class.rs
@@ -1,4 +1,5 @@
 #![allow(missing_docs)]
+#![allow(static_mut_refs)]
 
 use crate::class_prelude::*;
 use crate::device::{StringDescriptors, UsbDevice, UsbDeviceBuilder, UsbVidPid};

--- a/tests/test_class_host/device.rs
+++ b/tests/test_class_host/device.rs
@@ -65,13 +65,7 @@ impl DeviceHandles {
 
     /// Cleanup the device following a test
     pub fn post_test(&mut self) -> rusb::Result<()> {
-        let res = self.release_interface(TEST_INTERFACE);
-        if let Err(err) = res {
-            println!("Failed to release interface: {}", err);
-            return res;
-        }
-
-        Ok(())
+        self.release_interface(TEST_INTERFACE)
     }
 }
 

--- a/tests/test_class_host/main.rs
+++ b/tests/test_class_host/main.rs
@@ -6,14 +6,11 @@ mod device;
 /// cannot be run in parallel.
 mod tests;
 
-use crate::device::open_device;
+use crate::device::UsbContext;
 use crate::tests::{get_tests, TestFn};
 use std::io::prelude::*;
 use std::io::stdout;
 use std::panic;
-use std::thread;
-use std::time::Duration;
-use usb_device::device::CONFIGURATION_VALUE;
 
 fn main() {
     let tests = get_tests();
@@ -21,51 +18,15 @@ fn main() {
 }
 
 fn run_tests(tests: &[(&str, TestFn)]) {
-    const INTERFACE: u8 = 0;
-
     println!("test_class_host starting");
     println!("looking for device...");
 
-    let ctx = rusb::Context::new().expect("create libusb context");
-
-    // Look for the device for about 5 seconds in case it hasn't finished enumerating yet
-    let mut dev = Err(rusb::Error::NoDevice);
-    for _ in 0..50 {
-        dev = open_device(&ctx);
-        if dev.is_ok() {
-            break;
-        }
-
-        thread::sleep(Duration::from_millis(100));
-    }
-
-    let mut dev = match dev {
-        Ok(d) => d,
-        Err(err) => {
-            println!("Did not find a TestClass device. Make sure the device is correctly programmed and plugged in. Last error: {}", err);
-            return;
-        }
-    };
+    let mut ctx = UsbContext::new().expect("create libusb context");
 
     println!("\nrunning {} tests", tests.len());
 
     let mut success = 0;
     for (name, test) in tests {
-        if let Err(err) = dev.reset() {
-            println!("Failed to reset the device: {}", err);
-            return;
-        }
-
-        if let Err(err) = dev.set_active_configuration(CONFIGURATION_VALUE) {
-            println!("Failed to set active configuration: {}", err);
-            return;
-        }
-
-        if let Err(err) = dev.claim_interface(INTERFACE) {
-            println!("Failed to claim interface: {}", err);
-            return;
-        }
-
         print!("test {} ... ", name);
         let _ = stdout().flush();
 
@@ -75,15 +36,14 @@ fn run_tests(tests: &[(&str, TestFn)]) {
             let hook = panic::take_hook();
             panic::set_hook(Box::new(|_| {}));
             let res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-                test(&mut dev, &mut out);
+                test(&mut ctx, &mut out);
             }));
             panic::set_hook(hook);
 
             res
         };
 
-        dev.release_interface(INTERFACE)
-            .expect("failed to release interface");
+        ctx.cleanup_after_test().expect("post test cleanup failed");
 
         if let Err(err) = res {
             let err = if let Some(err) = err.downcast_ref::<&'static str>() {

--- a/tests/test_class_host/main.rs
+++ b/tests/test_class_host/main.rs
@@ -43,7 +43,10 @@ fn run_tests(tests: &[(&str, TestFn)]) {
             res
         };
 
-        ctx.cleanup_after_test().expect("post test cleanup failed");
+        if let Err(err) = ctx.cleanup_after_test() {
+            println!("Failed to release interface: {}", err);
+            panic!("post test cleanup failed");
+        }
 
         if let Err(err) = res {
             let err = if let Some(err) = err.downcast_ref::<&'static str>() {


### PR DESCRIPTION
Background can be found at https://github.com/atsamd-rs/atsamd/pull/738 .

The USB spec says that the SETUP transactions used with control endpoints must always be accepted by the device [1], and at least in the Microchip SAMD21's USB peripheral that behaviour is handled in hardware [2].  We've observed that some hosts will send an OUT ZLP, followed very shortly by a SETUP for a new transaction - on the SAMD21 parts this results in the OUT data (none, in this case) being overwritten by SETUP, which in the existing implementation results in an overflow error (since `read()` was called with a zero length slice for the OUT ZLP, but >0 bytes are available from the SETUP that overwrote it).  The user-observable result is that the device fails to enumerate at all on some hosts, or sporadically on others.

In light of this, it seems the control pipe code needs some way to differentiate reads of OUT data from reads of SETUP data.  This PR changes the existing `read()` methods to return an error if SETUP data is present, making it specific to OUT data, and adds a new `read_setup()` method specifically for reading SETUP data.

Most of the commits/diff here are work on the test framework, to add a new test that resets the device and times how long it takes to re-enumerate.  The test is a bit crude, but seems to validate the changes to the read methods.

[1] USB 2.0 spec section 5.5.5 Control Transfer Data Sequences:
> If a Setup transaction is received by an endpoint before a previously initiated control transfer is completed,
> the device must abort the current transfer/operation and handle the new control Setup transaction. A Setup
> transaction should not normally be sent before the completion of a previous control transfer. However, if a
> transfer is aborted, for example, due to errors on the bus, the host can send the next Setup transaction
> prematurely from the endpoint’s perspective.

[2] SAMD21 datasheet DS40001882H section 32.6.2.6 Management of SETUP Transactions.  The key thing here is that the data is copied in to the buffer regardless of BK0RDY.