### PR TITLE
Support for USB 1.0 and 1.0 in UsbRev enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 * `DummyUsbBus` without functionality to allow examples that actually compile (but not run).
+* Extended `UsbRev` enum with variants for USB 1.0 and 1.1.
 
 ### Changed
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -34,6 +34,10 @@ const MAX_ENDPOINTS: usize = 16;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u16)]
 pub enum UsbRev {
+    /// USB 1.0 compliance
+    Usb100 = 0x100,
+    /// USB 1.1 compliance
+    Usb110 = 0x110,
     /// USB 2.0 compliance
     Usb200 = 0x200,
     /// USB 2.1 compliance.


### PR DESCRIPTION
The UsbRev enum only has support for specification 2.0 and 2.1. Unless there's a reason not to add older revisions, 1.0 and 1.1 should also be supported.