### PR TITLE
fix: impl `Sync` for `UsbBusAllocator`

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -318,6 +318,8 @@ impl<B: UsbBus> UsbBusAllocator<B> {
     }
 }
 
+unsafe impl<T> Sync for UsbBusAllocator<T> where T: Sync + UsbBus {}
+
 /// A handle for a USB interface that contains its number.
 #[derive(Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,4 +289,5 @@ fn _ensure_sync() {
     ensure_sync::<crate::endpoint::EndpointIn<DummyBus>>();
     ensure_sync::<crate::endpoint::EndpointOut<DummyBus>>();
     ensure_sync::<DummyClass<'_, DummyBus>>();
+    ensure_sync::<UsbBusAllocator<DummyBus>>();
 }


### PR DESCRIPTION
Fixes an issue that I think arose in https://github.com/rust-embedded-community/usb-device/pull/149. Because `UsbBus` no longer requires `Sync`, then the trait is no longer auto implemented.